### PR TITLE
Added worker Node for kuber in new Terraform folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.terraform
+.terraform.tfstate.lock.info
+terraform.tfstate
+terraform.tfstate.backup
+Temp.pem
+access_key
+secret_key

--- a/ReverseProxy/Dockerfile
+++ b/ReverseProxy/Dockerfile
@@ -3,4 +3,3 @@ WORKDIR /app
 COPY ReverseProxy /app
 EXPOSE 8080
 CMD [ "./ReverseProxy" ]
-

--- a/terraform/setup_node_env.sh
+++ b/terraform/setup_node_env.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#Remove Bad Docker Installs
+apt-get remove docker docker-engine docker.io containerd runc
+
+apt-get update
+
+#Make sure everything required is installed
+apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+
+#grab key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+apt-key fingerprint 0EBFCD88
+
+#Add Download location
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+apt-get update
+
+#Install Docker Proper
+apt-get -y install docker-ce docker-ce-cli containerd.io
+
+#Setup Docker.service
+systemctl enable docker
+systemctl start docker
+
+
+#Kuber requirements
+sed -i '/swap/d' /etc/fstab
+swapoff -a
+
+#Get Kubelet kubeadm kubectl
+apt-get update && apt-get install -y apt-transport-https curl
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+apt-get update
+apt-get install -y kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+#Start Kubelet for overlay connections
+systemctl enable kubelet
+systemctl start kubelet
+
+#Env setup, can now connect to a master node
+#Note to self. If error check ports in worker.tf
+#probably need to expose more ports, check kubeadm 
+#install page for list of ports used by overlay network
+#https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -1,0 +1,56 @@
+provider "aws" {
+  #Two localfiles names as such. Each contains what they say, given to you from AWS.
+  #DO NOT UPLOAD THESE FILES, make sure they are masked by the .gitignore
+  access_key = "${file("./access_key")}"
+  secret_key = "${file("./secret_key")}"
+  region     = "us-east-2"
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-0fc20dd1da406780b"
+  instance_type = "t2.micro"
+
+  #Generate your own Key_Name from AWS and use that here
+  #DO NOT UPLOAD THESE FILES, make sure they are masked by the .gitignore
+  key_name = "Temp"
+  security_groups = ["${aws_security_group.SSH.name}"]
+
+  connection {
+    user = "ubuntu"
+    type = "ssh"
+    private_key = "${file("./Temp.pem")}"
+    host =  self.public_ip
+    timeout = "4m"
+  }
+  provisioner "file" {
+    source      = "setup_node_env.sh"
+    destination = "/tmp/setup_node_env.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo /bin/bash /tmp/setup_node_env.sh",
+    ]
+  }
+
+}
+
+resource "aws_security_group" "SSH" {
+  name        = "allow_ssh"
+  description = "Allow SSH traffic"
+
+
+  ingress {
+    from_port   = 22 
+    to_port     = 22
+    protocol =   "tcp"
+
+    cidr_blocks =  ["64.189.196.114/32"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
Kuber worker node can now be configured and launched automatically as AWS VM through terraform, ready for a master node connection and assignment of containers. Works only on AWS for right now, so no azure support currently. Easily expanded to act as master node but free teir only has one cpu, so SSH'ing into the AWS server and running kubecmd init --flags will only cause an error. Should you have the dolla dolla, this will work like a charm.