### PR TITLE
Added New Folder for Kubernetes

### DIFF
--- a/kubernetes/pods/html-server.yaml
+++ b/kubernetes/pods/html-server.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: html-server
+  labels:
+    app: zach-html
+
+spec:
+  containers:
+  - name: zach-html
+    image: zachthomas823/server
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 4000

--- a/kubernetes/services/client-server.yaml
+++ b/kubernetes/services/client-server.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: client-server
+
+spec:
+  type: NodePort
+  ports:
+    - nodePort: 30100
+      targetPort: 4000
+      port: 80
+
+  selector:
+    app: zach-html

--- a/terraform/setup_master.sh
+++ b/terraform/setup_master.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#Remove Bad Docker Installs
+apt-get remove docker docker-engine docker.io containerd runc
+
+apt-get update
+
+#Make sure everything required is installed
+apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+
+#grab key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+apt-key fingerprint 0EBFCD88
+
+#Add Download location
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+apt-get update
+
+#Install Docker Proper
+apt-get -y install docker-ce docker-ce-cli containerd.io
+
+#Setup Docker.service
+systemctl enable docker
+systemctl start docker
+
+setenforce 0
+sed -i --follow-symlinks 's/^SELINUX=enforcing/SELINUX=disabled/' /etc/sysconfig/selinux
+
+systemctl disable firewalld
+systemctl stop firewalld
+
+#Kuber requirements
+sed -i '/swap/d' /etc/fstab
+swapoff -a
+
+#Get Kubelet kubeadm kubectl
+apt-get update && apt-get install -y apt-transport-https curl
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+apt-get update
+apt-get install -y kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+#Start Kubelet for overlay connections
+systemctl enable kubelet
+systemctl start kubelet
+
+kubeadm init
+
+mkdir /home/ubuntu/.kube
+cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+chown -R ubuntu:ubuntu /home/ubuntu/.kube
+
+kubectl create -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml
+
+iptables -P FORWARD ACCEPT

--- a/terraform/setup_worker.sh
+++ b/terraform/setup_worker.sh
@@ -32,6 +32,11 @@ apt-get -y install docker-ce docker-ce-cli containerd.io
 systemctl enable docker
 systemctl start docker
 
+setenforce 0
+sed -i --follow-symlinks 's/^SELINUX=enforcing/SELINUX=disabled/' /etc/sysconfig/selinux
+
+systemctl disable firewalld
+systemctl stop firewalld
 
 #Kuber requirements
 sed -i '/swap/d' /etc/fstab
@@ -50,9 +55,3 @@ apt-mark hold kubelet kubeadm kubectl
 #Start Kubelet for overlay connections
 systemctl enable kubelet
 systemctl start kubelet
-
-#Env setup, can now connect to a master node
-#Note to self. If error check ports in worker.tf
-#probably need to expose more ports, check kubeadm 
-#install page for list of ports used by overlay network
-#https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -6,7 +6,7 @@ provider "aws" {
   region     = "us-east-2"
 }
 
-resource "aws_instance" "example" {
+resource "aws_instance" "worker" {
   ami           = "ami-0fc20dd1da406780b"
   instance_type = "t2.micro"
 
@@ -23,15 +23,58 @@ resource "aws_instance" "example" {
     timeout = "4m"
   }
   provisioner "file" {
-    source      = "setup_node_env.sh"
-    destination = "/tmp/setup_node_env.sh"
+    source      = "setup_worker.sh"
+    destination = "/tmp/setup_worker.sh"
   }
   provisioner "remote-exec" {
     inline = [
-      "sudo /bin/bash /tmp/setup_node_env.sh",
+      "sudo /bin/bash /tmp/setup_worker.sh",
+    ]
+  }
+}
+
+resource "aws_instance" "master" {
+  ami           = "ami-0fc20dd1da406780b"
+  instance_type = "t2.medium"
+
+  #Generate your own Key_Name from AWS and use that here
+  #DO NOT UPLOAD THESE FILES, make sure they are masked by the .gitignore
+  key_name = "Temp"
+  security_groups = ["${aws_security_group.SSH.name}"]
+
+  connection {
+    user = "ubuntu"
+    type = "ssh"
+    private_key = "${file("./Temp.pem")}"
+    host =  self.public_ip
+    timeout = "4m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir pods",
+      "mkdir services",
     ]
   }
 
+  provisioner "file" {
+    source      = "setup_master.sh"
+    destination = "/tmp/setup_master.sh"
+  }
+  provisioner "file" {
+    source      = "../kubernetes/services/client-server.yaml"
+    destination = "/home/ubuntu/services/client-server.yaml"
+  }
+  provisioner "file" {
+    source      = "../kubernetes/pods/html-server.yaml"
+    destination = "/home/ubuntu/pods/html-server.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo /bin/bash /tmp/setup_master.sh",
+    ]
+  }
 }
 
 resource "aws_security_group" "SSH" {
@@ -40,11 +83,11 @@ resource "aws_security_group" "SSH" {
 
 
   ingress {
-    from_port   = 22 
-    to_port     = 22
-    protocol =   "tcp"
+    from_port   = 0 
+    to_port     = 0
+    protocol =   "-1"
 
-    cidr_blocks =  ["64.189.196.114/32"]
+    cidr_blocks =  ["0.0.0.0/0"]
   }
 
   egress {


### PR DESCRIPTION
Kubernetes now has its own folder for the setup and creation of yaml scripts for deployments, pods, and services. Two have been created. A nodprt service will point to any html servers running zach's public docker file. The terraform script has also been updated to move the kubernetes files to the master node. It also configures both master and worker node.